### PR TITLE
支持运用外来插件的变量机制

### DIFF
--- a/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/AiyatsbusEnchantment.kt
+++ b/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/AiyatsbusEnchantment.kt
@@ -20,6 +20,7 @@ import cc.polarastrum.aiyatsbus.core.data.*
 import cc.polarastrum.aiyatsbus.core.data.registry.Target
 import cc.polarastrum.aiyatsbus.core.data.registry.Rarity
 import cc.polarastrum.aiyatsbus.core.data.trigger.Trigger
+import cc.polarastrum.aiyatsbus.core.util.Function2
 import cc.polarastrum.aiyatsbus.core.util.roman
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
@@ -88,6 +89,8 @@ interface AiyatsbusEnchantment {
      * 附魔的变量显示与替换
      */
     val variables: Variables
+
+    val outsideVariables: Map<String, Function2<Int, String>>
 
     /**
      * 附魔显示

--- a/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/AiyatsbusEnchantmentBase.kt
+++ b/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/AiyatsbusEnchantmentBase.kt
@@ -22,6 +22,7 @@ import cc.polarastrum.aiyatsbus.core.data.*
 import cc.polarastrum.aiyatsbus.core.data.registry.Target
 import cc.polarastrum.aiyatsbus.core.data.registry.Rarity
 import cc.polarastrum.aiyatsbus.core.data.trigger.Trigger
+import cc.polarastrum.aiyatsbus.core.util.Function2
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
 import taboolib.common.util.unsafeLazy
@@ -56,6 +57,8 @@ abstract class AiyatsbusEnchantmentBase(
             ?: cc.polarastrum.aiyatsbus.core.aiyatsbusRarity(AiyatsbusSettings.defaultRarity) ?: error("Enchantment $id has an unknown rarity")
 
     override val variables: Variables = Variables(config.getConfigurationSection("variables"))
+
+    override val outsideVariables: Map<String, Function2<Int, String>> = mutableMapOf();
 
     override val targets: List<Target>
         get() = config.getStringList("targets").mapNotNull(::aiyatsbusTarget)

--- a/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/data/Displayer.kt
+++ b/project/common/src/main/kotlin/cc/polarastrum/aiyatsbus/core/data/Displayer.kt
@@ -96,6 +96,7 @@ data class Displayer(
     ): Map<String, String> {
         val tmp = enchant.variables.variables(level, item, true)
             .mapValues { it.value.toString() }.toMutableMap() // 因为是显示, 这里的变量可以直接转为字符串
+        tmp.putAll(enchant.outsideVariables.mapValues { it.value.apply(level) })
         val lv = level ?: enchant.basicData.maxLevel
         tmp["id"] = enchant.basicData.id
         tmp["name"] = enchant.basicData.name


### PR DESCRIPTION
添加了个变量来专门存其他插件自定义附魔的变量机制，来应用到原生显示机制
其他插件把变量塞到新增的map，第一项是变量名，第二项是根据等级获取显示字符串的lambda
![74291a28dc0b9556420b5bde10d9cec8](https://github.com/user-attachments/assets/7a250a71-58fd-4101-a805-d1fe40b904dd)
![f2ac8752af79e9e42b370e900c926a6f](https://github.com/user-attachments/assets/9310caef-dbaa-4c37-9371-e239600fc4c6)
